### PR TITLE
Fix: App Script URL V7 & Backend Syntax

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@
 // TODO: Update these values for your deployment.
 
 // Google Apps Script "web app" URL that writes to your Google Sheet.
-export const APP_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbzwaWCVk3AcrX35caJJMaSA831LWjrrqSGg47Jeh3v5nCbA6AFaqtdmBzV4fypUIG8B/exec';
+export const APP_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbyI62z58KHNw_3355ebA5Zqnetd8CxT_KPHaZWi05YC9WLKK0FD4jYSEwRDm9Jy2M_c/exec';
 
 // Player access code (simple shared gate).
 export const ACCESS_CODE = 'playercode';


### PR DESCRIPTION
Updates the API URL to V7 and fixes the doGet syntax error for approvals.